### PR TITLE
handle non-us language environments properly

### DIFF
--- a/gitignore_plugin.py
+++ b/gitignore_plugin.py
@@ -171,7 +171,8 @@ def repo_ignored_paths(git_repo):
         ['git', 'clean', '-ndX'],
         stdout=subprocess.PIPE,
         cwd=git_repo,
-        startupinfo=startupinfo
+        startupinfo=startupinfo,
+        env={'LANG':'C'}
     ).stdout.read()
     
     command_output = command_output.decode('utf-8', 'ignore')


### PR DESCRIPTION
If used on a machine with non-us or C language settings the used git command fails to parse since it does not output the desired strings.
Added a LANG=C environment making the git command output predictable.